### PR TITLE
passes on detailed var

### DIFF
--- a/Transformer/AbstractCollection.php
+++ b/Transformer/AbstractCollection.php
@@ -58,7 +58,7 @@ abstract class AbstractCollection
         $ret = array();
 
         foreach ($collection as $model){
-            array_push($ret, $this->getModelTransformer()->transform($model));
+            array_push($ret, $this->getModelTransformer()->transform($model, $detailed));
         }
 
         return $ret;


### PR DESCRIPTION
`$detailed` var was not being passed on to Model Transformer, this PR fixes that issue